### PR TITLE
weth simple deposit

### DIFF
--- a/contracts/interfaces/external/IWETH9.sol
+++ b/contracts/interfaces/external/IWETH9.sol
@@ -6,12 +6,10 @@ import "@elliottech/lighter-v2-core/contracts/interfaces/external/IERC20Minimal.
 /// @title Interface for WETH9 on Arbitrum
 /// @notice token functions to facilitate the wrap and unwrap functions during deposit and withdrawal of WETH token
 interface IWETH9 is IERC20Minimal {
-    /// @notice Withdraw wrapped ether to get ether to a recipient address
-    /// @param recipient address to send unwrapped ether
-    /// @param amount amount of WETH to be unwrapped during withdrawal
-    function withdrawTo(address recipient, uint256 amount) external;
+    /// @notice withdraws an amount of tokens from the contract and sends ether back to the sender.
+    /// @param amount The amount of tokens to withdraw.
+    function withdraw(uint256 amount) external;
 
-    /// @notice wrap the ether and transfer to a recipient address
-    /// @param recipient address to send wrapped ether
-    function depositTo(address recipient) external payable;
+    /// @notice deposits ether into the contract and mints corresponding tokens to the sender.
+    function deposit() external payable;
 }

--- a/contracts/libraries/PeripheryErrors.sol
+++ b/contracts/libraries/PeripheryErrors.sol
@@ -29,6 +29,9 @@ library PeripheryErrors {
     /// @notice Thrown when native token refund fails
     error LighterV2Router_NativeRefundFailed();
 
+    /// @notice Thrown when unwrapping of native token fails
+    error LighterV2Router_UnwrapFailed();
+
     /*//////////////////////////////////////////////////////////////////////////
                                       LIGHTER-V2-PARSE-CALLDATA
     //////////////////////////////////////////////////////////////////////////*/


### PR DESCRIPTION
The initial `Router` contract took advantage of the `depositTo` and `withdrawTo` methods from the WETH (wrapped native) token contract. Those methods are only present in the [arbitrum contract](https://arbiscan.io/token/0x82af49447d8a07e3bd95bd0d56f35241523fbab1), and they are missing from the [polygon](https://polygonscan.com/token/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270#code), [optimism](https://optimistic.etherscan.io/token/0x4200000000000000000000000000000000000006#code) and [bsc](https://bscscan.com/address/0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c#code).

In order to deploy on the other networks, the `WETH9` interface was simplified and the simple methods are used instead.